### PR TITLE
Add Cloudsmith (pkg management for composer)

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ A curated list of awesome PHP frameworks, libraries and software.
 * [symfony/symfony](https://github.com/symfony/symfony) - The Symfony PHP framework
 * [fzaninotto/Faker](https://github.com/fzaninotto/Faker) - Faker is a PHP library that generates fake data for you
 * [composer/composer](https://github.com/composer/composer) - Dependency Manager for PHP
+* [Cloudsmith](https://cloudsmith.io) - A fully managed package management SaaS with PHP/Composer support (and many others).
 * [bcit-ci/CodeIgniter](https://github.com/bcit-ci/CodeIgniter) - Open Source PHP Framework (originally from EllisLab)
 * [domnikl/DesignPatternsPHP](https://github.com/domnikl/DesignPatternsPHP) - sample code for several design patterns in PHP
 * [guzzle/guzzle](https://github.com/guzzle/guzzle) - Guzzle, an extensible PHP HTTP client


### PR DESCRIPTION
Hi! This PR adds a link to Cloudsmith, which is a package management service SaaS. It's commercial, but it is completely free for open-source and it has generous free tiers otherwise. It has first-class support for php/composer repositories (and many other package formats, such as Python/Ruby), plus org/teams management, granular access controls, private repositories, repository-specific entitlements, a worldwide content distribution network, webhooks, access logs, etc. Thank you. :-)